### PR TITLE
Use stable keys for all mapped lists

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -311,9 +311,9 @@ function FilterSelect({ label, value, setValue, options }:{ label:string; value:
 function CardsView({ records, selected, onToggle }: { records: DirectoryRecord[]; selected: DirectoryRecord | null; onToggle: (r: DirectoryRecord) => void }){
   return (
     <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
-      {records.map((r, idx) => (
+      {records.map((r) => (
         <Card
-          key={idx}
+          key={personId(r)}
           className="rounded-2xl shadow-sm hover:shadow transition cursor-pointer h-full flex flex-col min-h-[240px]"
           onClick={() => onToggle(r)}
         >
@@ -379,8 +379,8 @@ function TableView({ records, onOpen }: { records: DirectoryRecord[]; onOpen:(r:
           </TableRow>
         </TableHeader>
         <TableBody>
-          {records.map((r, i)=> (
-            <TableRow key={i} className="cursor-pointer hover:bg-slate-50" onClick={()=> onOpen(r)}>
+          {records.map((r)=> (
+            <TableRow key={personId(r)} className="cursor-pointer hover:bg-slate-50" onClick={()=> onOpen(r)}>
               <TableCell className="font-medium">{r.Name}</TableCell>
               <TableCell>{r.Title}</TableCell>
               <TableCell>{r.Department}</TableCell>
@@ -637,8 +637,8 @@ function OrgMarketingChart({ rows, divisionName, onOpenCard }:{ rows: DirectoryR
   return (
     <div ref={contRef} className="relative w-full">
       <svg className="absolute inset-0 -z-10 pointer-events-none" width={svgBox.w} height={svgBox.h} viewBox={`0 0 ${svgBox.w} ${svgBox.h}`} preserveAspectRatio="none">
-        {sharedSegments.map((s, i)=> (
-          <path key={i} d={`M ${s.x1} ${s.y1} L ${s.x2} ${s.y2}`} fill="none" stroke="#CBD5E1" strokeWidth={2} />
+        {sharedSegments.map((s)=> (
+          <path key={`${s.x1}-${s.y1}-${s.x2}-${s.y2}`} d={`M ${s.x1} ${s.y1} L ${s.x2} ${s.y2}`} fill="none" stroke="#CBD5E1" strokeWidth={2} />
         ))}
       </svg>
 
@@ -986,8 +986,8 @@ function ResourceList({ record }:{ record: DirectoryRecord }){
     <div className="space-y-2">
       <div className="font-medium">Resources</div>
       <div className="space-y-2">
-        {visible.map((res, i)=>(
-          <div key={i} className="rounded-xl border p-3 hover:bg-slate-50 flex items-center gap-3">
+        {visible.map((res)=>(
+          <div key={res.label} className="rounded-xl border p-3 hover:bg-slate-50 flex items-center gap-3">
             <div className="flex-1 min-w-0">
               <div className="text-sm font-medium break-words">{res.label}</div>
               {res.desc && <div className="text-xs text-slate-600 break-words">{res.desc}</div>}
@@ -1089,7 +1089,7 @@ function DataQA({ records }:{ records: DirectoryRecord[] }){
   if (!messages.length) return <div className='text-sm text-slate-600'>No data issues found.</div>;
   return (
     <ul className='text-sm text-slate-700 list-disc pl-5 space-y-1'>
-      {messages.map((m,i)=> <li key={i}>{m}</li>)}
+      {messages.map((m)=> <li key={m}>{m}</li>)}
     </ul>
   );
 }

--- a/src/App_KEEP.tsx
+++ b/src/App_KEEP.tsx
@@ -274,8 +274,8 @@ function FilterSelect({ label, value, setValue, options }:{ label:string; value:
 function CardsView({ records, selected, onToggle }: { records: DirectoryRecord[]; selected: DirectoryRecord | null; onToggle: (r: DirectoryRecord) => void }){
   return (
     <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
-      {records.map((r, idx)=>(
-        <Card key={idx} className="rounded-2xl shadow-sm hover:shadow transition cursor-pointer" onClick={()=> onToggle(r)}>
+      {records.map((r)=>(
+        <Card key={personId(r)} className="rounded-2xl shadow-sm hover:shadow transition cursor-pointer" onClick={()=> onToggle(r)}>
           <CardHeader className="pb-2">
             <CardTitle className="text-base">
               <div className="font-medium leading-snug break-words">{r.Name || '(No name)'}</div>
@@ -329,8 +329,8 @@ function TableView({ records, onOpen }: { records: DirectoryRecord[]; onOpen:(r:
           </TableRow>
         </TableHeader>
         <TableBody>
-          {records.map((r, i)=> (
-            <TableRow key={i} className="cursor-pointer hover:bg-slate-50" onClick={()=> onOpen(r)}>
+          {records.map((r)=> (
+            <TableRow key={personId(r)} className="cursor-pointer hover:bg-slate-50" onClick={()=> onOpen(r)}>
               <TableCell className="font-medium">{r.Name}</TableCell>
               <TableCell>{r.Title}</TableCell>
               <TableCell>{r.Department}</TableCell>
@@ -610,7 +610,7 @@ function OrgChart(
         ) : (
           <div className="space-y-8">
             {levels.map((row, i) => (
-              <div key={i} className="relative">
+              <div key={row.map(n => personId(n)).join('|')} className="relative">
                 {i < levels.length - 1 && (
                   <div className="absolute left-8 right-8 top-[calc(100%+0.25rem)] h-px bg-slate-300" />
                 )}
@@ -805,8 +805,8 @@ function ResourceList({ record }:{ record: DirectoryRecord }){
     <div className="space-y-2">
       <div className="font-medium">Resources</div>
       <div className="space-y-2">
-        {visible.map((res, i)=>(
-          <div key={i} className="rounded-xl border p-3 hover:bg-slate-50 flex items-center gap-3">
+        {visible.map((res)=>(
+          <div key={res.label} className="rounded-xl border p-3 hover:bg-slate-50 flex items-center gap-3">
             <div className="flex-1 min-w-0">
               <div className="text-sm font-medium break-words">{res.label}</div>
               {res.desc && <div className="text-xs text-slate-600 break-words">{res.desc}</div>}
@@ -909,7 +909,7 @@ function DataQA({ records }:{ records: DirectoryRecord[] }){
   if (!messages.length) return <div className='text-sm text-slate-600'>No data issues found.</div>;
   return (
     <ul className='text-sm text-slate-700 list-disc pl-5 space-y-1'>
-      {messages.map((m,i)=> <li key={i}>{m}</li>)}
+      {messages.map((m)=> <li key={m}>{m}</li>)}
     </ul>
   );
 }

--- a/src/App_claude.tsx
+++ b/src/App_claude.tsx
@@ -472,8 +472,8 @@ function CardsView({ records, selected, onToggle, favorites, onToggleFavorite }:
 }){
   return (
     <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
-      {records.map((r, idx)=>(
-        <Card key={idx} className="rounded-2xl shadow-sm hover:shadow-md transition-all cursor-pointer group" onClick={()=> onToggle(r)}>
+      {records.map((r)=>(
+        <Card key={personId(r)} className="rounded-2xl shadow-sm hover:shadow-md transition-all cursor-pointer group" onClick={()=> onToggle(r)}>
           <CardHeader className="pb-2">
             <CardTitle className="text-base">
               <div className="flex items-start justify-between gap-2">
@@ -546,8 +546,8 @@ function TableView({ records, onOpen, favorites, onToggleFavorite }: {
           </tr>
         </thead>
         <tbody className="divide-y divide-slate-200">
-          {records.map((r, i)=> (
-            <tr key={i} className="cursor-pointer hover:bg-slate-50 transition-colors" onClick={()=> onOpen(r)}>
+          {records.map((r)=> (
+            <tr key={personId(r)} className="cursor-pointer hover:bg-slate-50 transition-colors" onClick={()=> onOpen(r)}>
               <td className="px-4 py-3">
                 <Button
                   variant="ghost"


### PR DESCRIPTION
## Summary
- Use `personId` instead of array indexes for card and table row keys
- Replace remaining index-based keys with identifiers derived from record data
- Ensure all mapped collections across the codebase rely on stable keys

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689cc6af47e0832b8566ef09ae1e033e