### PR TITLE
Add vitest configuration and unit tests for helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.453.0",
@@ -23,6 +24,7 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.5",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,8 +52,8 @@ export type DirectoryRecord = {
 };
 
 // ----------------------------- Constants -----------------------------
-const REGION_KEYS = ["South", "Southeast", "Midwest", "Northeast", "Pacific"] as const;
-const REGION_COLORS: Record<string, string> = {
+export const REGION_KEYS = ["South", "Southeast", "Midwest", "Northeast", "Pacific"] as const;
+export const REGION_COLORS: Record<string, string> = {
   South: "#092C48",
   Southeast: "#B72B33",
   Northeast: "#74922C",
@@ -62,12 +62,12 @@ const REGION_COLORS: Record<string, string> = {
 };
 
 // ----------------------------- Helpers -----------------------------
-const truthyFlag = (v?: string) => {
+export const truthyFlag = (v?: string) => {
   if (!v) return false;
   const s = String(v).trim().toLowerCase();
   return ["y","yes","true","1","✓","x"].includes(s);
 };
-const deriveRegions = (r: DirectoryRecord) => REGION_KEYS.filter(k => truthyFlag(r[k])).map(k=>k);
+export const deriveRegions = (r: DirectoryRecord) => REGION_KEYS.filter(k => truthyFlag(r[k])).map(k=>k);
 const normalize = (s?: string) => (s || '').trim();
 const personId = (r: DirectoryRecord) => normalize(r['Person ID']) || normalize(r.Email);
 const managerId = (r: DirectoryRecord) => normalize(r['Manager ID']) || normalize(r['Manager Email']);
@@ -101,7 +101,7 @@ function trimAll<T extends Record<string, any>>(obj: T): T {
   return out;
 }
 
-function RegionPill({ name }:{ name:string }){
+export function RegionPill({ name }:{ name:string }){
   const color = REGION_COLORS[name] || '#5B7183';
   const style: React.CSSProperties = { color, borderColor: color, borderWidth: 1 };
   return <span aria-label={`Region ${name}`} className="inline-flex items-center px-2 py-0.5 text-xs rounded-full bg-white border" style={style}>{name}</span>;

--- a/tests/RegionPill.test.tsx
+++ b/tests/RegionPill.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { RegionPill, REGION_COLORS } from '@/App';
+import { describe, it, expect } from 'vitest';
+
+describe('RegionPill', () => {
+  it('renders the region name with appropriate color', () => {
+    const name = 'South';
+    const html = renderToStaticMarkup(<RegionPill name={name} />);
+    expect(html).toContain(`Region ${name}`);
+    expect(html).toContain(name);
+    expect(html).toContain(`color:${REGION_COLORS[name]}`);
+    expect(html).toContain(`border-color:${REGION_COLORS[name]}`);
+  });
+});

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { truthyFlag, deriveRegions, type DirectoryRecord } from '@/App';
+
+describe('truthyFlag', () => {
+  it('returns true for yes-like values', () => {
+    expect(truthyFlag('yes')).toBe(true);
+    expect(truthyFlag('Y')).toBe(true);
+    expect(truthyFlag('1')).toBe(true);
+    expect(truthyFlag('✓')).toBe(true);
+  });
+
+  it('returns false for falsy values', () => {
+    expect(truthyFlag('no')).toBe(false);
+    expect(truthyFlag(undefined)).toBe(false);
+    expect(truthyFlag('')).toBe(false);
+  });
+});
+
+describe('deriveRegions', () => {
+  it('returns regions with truthy flags', () => {
+    const record: DirectoryRecord = { South: 'yes', Midwest: 'true', Pacific: 'no' };
+    expect(deriveRegions(record)).toEqual(['South', 'Midwest']);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "isolatedModules": true,
     "strict": true,
     "baseUrl": ".",
-    "paths": { "@/*": ["./src/*"] }
+    "paths": { "@/*": ["./src/*"] },
+    "types": ["vitest"]
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,8 @@ import path from 'path'
 export default defineConfig({
   plugins: [react()],
   resolve: { alias: { '@': path.resolve(__dirname, './src') } },
+  test: {
+    globals: true,
+    environment: 'happy-dom'
+  }
 })


### PR DESCRIPTION
## Summary
- add vitest test script and configuration
- export helper utilities and create unit tests for truthyFlag, deriveRegions and RegionPill component

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cc6b33ae8832ba6a3cd8e24813c0a