### PR TITLE
fix: clean duplicate exports in sheet component

### DIFF
--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,39 +1,5 @@
 import React from 'react'
 
-
-interface SheetProps {
-  open: boolean
-  onOpenChange?: (open: boolean) => void
-  children: React.ReactNode
-}
-
-export function Sheet({ open, onOpenChange, children }: SheetProps) {
-  return open ? children : null
-}
-
-interface SheetContentProps {
-  className?: string
-  children: React.ReactNode
-}
-
-export function SheetContent({ className = '', children }: SheetContentProps) {
-  return <div className={`fixed right-0 top-0 h-full w-full sm:w-[28rem] bg-white border-l shadow-xl p-4 overflow-auto ${className}`}>{children}</div>
-}
-
-interface SheetHeaderProps {
-  children: React.ReactNode
-}
-
-export function SheetHeader({ children }: SheetHeaderProps) {
-  return <div className='mb-2'>{children}</div>
-}
-
-interface SheetTitleProps {
-  children: React.ReactNode
-  className?: string
-}
-
-export function SheetTitle({ children, className = '' }: SheetTitleProps) {
 function useFocusTrap(ref: React.RefObject<HTMLDivElement>) {
   React.useEffect(() => {
     const node = ref.current
@@ -48,18 +14,15 @@ function useFocusTrap(ref: React.RefObject<HTMLDivElement>) {
         el => !el.hasAttribute('disabled')
       )
 
-    const focusables = getFocusable()
-    focusables[0]?.focus()
-
-    function handleKeyDown(e: KeyboardEvent) {
+    const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'Tab') return
-      const current = getFocusable()
-      if (current.length === 0) {
+      const focusables = getFocusable()
+      if (focusables.length === 0) {
         e.preventDefault()
         return
       }
-      const first = current[0]
-      const last = current[current.length - 1]
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
       if (e.shiftKey) {
         if (document.activeElement === first) {
           e.preventDefault()
@@ -73,6 +36,9 @@ function useFocusTrap(ref: React.RefObject<HTMLDivElement>) {
       }
     }
 
+    const focusables = getFocusable()
+    focusables[0]?.focus()
+
     node.addEventListener('keydown', handleKeyDown)
     return () => {
       node.removeEventListener('keydown', handleKeyDown)
@@ -81,43 +47,37 @@ function useFocusTrap(ref: React.RefObject<HTMLDivElement>) {
   }, [ref])
 }
 
-export function Sheet({open, onOpenChange, children}: any){ return open ? children : null }
-export function SheetContent({className='', children}: any){
-  const contentRef = React.useRef<HTMLDivElement>(null)
-  useFocusTrap(contentRef)
-  return (
-    <div
-      className='fixed inset-0 z-[100] bg-black/30 flex'
-      aria-modal="true"
-    >
-      <div
-        ref={contentRef}
-        role='dialog'
-        className={`ml-auto h-full w-full sm:w-[28rem] bg-white border-l shadow-xl p-4 overflow-auto ${className}`}
-      >
-        {children}
-      </div>
-    </div>
-  )
+interface SheetProps {
+  open: boolean
+  onOpenChange?: (open: boolean) => void
+  children: React.ReactNode
 }
-export function SheetHeader({children}: any){ return <div className='mb-2'>{children}</div> }
-export function SheetTitle({children, className=''}: any){ return <div className={`text-xl font-semibold ${className}`}>{children}</div> }
-export function Sheet({ open, onOpenChange, children }: any) {
+
+export function Sheet({ open, onOpenChange, children }: SheetProps) {
   if (!open) return null
   return (
     <div className="fixed inset-0 z-[200]">
       <div
-      className="absolute inset-0 bg-black/30"
-      onClick={() => onOpenChange?.(false)}
+        className="absolute inset-0 bg-black/30"
+        onClick={() => onOpenChange?.(false)}
       />
       {children}
     </div>
   )
 }
 
-export function SheetContent({ className = '', children }: any) {
+interface SheetContentProps {
+  className?: string
+  children: React.ReactNode
+}
+
+export function SheetContent({ className = '', children }: SheetContentProps) {
+  const contentRef = React.useRef<HTMLDivElement>(null)
+  useFocusTrap(contentRef)
   return (
     <div
+      ref={contentRef}
+      role="dialog"
       className={`absolute inset-x-0 bottom-0 max-h-[90vh] bg-white border-t shadow-xl p-4 overflow-auto rounded-t-2xl ${className}`}
     >
       {children}
@@ -125,10 +85,21 @@ export function SheetContent({ className = '', children }: any) {
   )
 }
 
-export function SheetHeader({ children, className = '' }: any) {
+interface SheetHeaderProps {
+  className?: string
+  children: React.ReactNode
+}
+
+export function SheetHeader({ className = '', children }: SheetHeaderProps) {
   return <div className={className}>{children}</div>
 }
 
-export function SheetTitle({ children, className = '' }: any) {
+interface SheetTitleProps {
+  className?: string
+  children: React.ReactNode
+}
+
+export function SheetTitle({ className = '', children }: SheetTitleProps) {
   return <div className={`text-xl font-semibold ${className}`}>{children}</div>
 }
+


### PR DESCRIPTION
## Summary
- remove merge artifacts and duplicate exports in `sheet` component
- centralize `useFocusTrap` hook and export one variant of each sheet element

## Testing
- `npm run dev` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_689cd86f7138832bb714644c90e19b99