### PR TITLE
chore: remove vitest types from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,7 @@
     "isolatedModules": true,
     "strict": true,
     "baseUrl": ".",
-    "paths": { "@/*": ["./src/*"] },
-    "types": ["vitest"]
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src", "tests"]
 }


### PR DESCRIPTION
## Summary
- remove Vitest type reference from TypeScript config so build doesn't look for missing types

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cdec69f00832b919067ac10830b07