### PR TITLE
Improve browse search and org chart layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,21 +135,9 @@ export default function App() {
     });
   }, [data, division, department, team, region, query]);
 
-  useEffect(() => {
-    if (view !== "browse") return;
-    const q = query.trim().toLowerCase();
-    if (!q) return;
-    const matches = filtered.filter(
-      r => (r.Name || "").trim().toLowerCase() === q
-    );
-    if (matches.length === 1) {
-      const m = matches[0];
-      setSelected(m);
-      setBrowseDiv(null);
-      setBrowseDept(null);
-      setBrowseTeam(null);
-    }
-  }, [query, filtered, view]);
+  // When searching within browse view, simply show matching cards rather
+  // than automatically opening the full details sheet. This allows
+  // partial-name searches to surface basic contact cards.
 
   return (
     <TooltipProvider>
@@ -235,40 +223,50 @@ export default function App() {
           </div>
 
           {view === "browse" ? (
-            <BrowseView
-              data={filtered}
-              selectedDiv={browseDiv}
-              selectedDept={browseDept}
-              selectedTeam={browseTeam}
-              onDiv={(d) => {
-                setBrowseDiv(d);
-                setBrowseDept(null);
-                setBrowseTeam(null);
-              }}
-              onDept={(d) => {
-                setBrowseDept(d);
-                setBrowseTeam(null);
-              }}
-              onTeam={(t) => setBrowseTeam(t)}
-              onBack={() => {
-                if (browseTeam) setBrowseTeam(null);
-                else if (browseDept) setBrowseDept(null);
-                else if (browseDiv) setBrowseDiv(null);
-              }}
-              onRoot={() => {
-                setBrowseDiv(null);
-                setBrowseDept(null);
-                setBrowseTeam(null);
-              }}
-              onDivCrumb={() => {
-                setBrowseDept(null);
-                setBrowseTeam(null);
-              }}
-              onDeptCrumb={() => {
-                setBrowseTeam(null);
-              }}
-              onOpenCard={(r) => setSelected(r)}
-            />
+            query.trim() ? (
+              <CardsView
+                records={filtered}
+                selected={selected}
+                onToggle={(r) =>
+                  setSelected(selected && sameRecord(selected, r) ? null : r)
+                }
+              />
+            ) : (
+              <BrowseView
+                data={filtered}
+                selectedDiv={browseDiv}
+                selectedDept={browseDept}
+                selectedTeam={browseTeam}
+                onDiv={(d) => {
+                  setBrowseDiv(d);
+                  setBrowseDept(null);
+                  setBrowseTeam(null);
+                }}
+                onDept={(d) => {
+                  setBrowseDept(d);
+                  setBrowseTeam(null);
+                }}
+                onTeam={(t) => setBrowseTeam(t)}
+                onBack={() => {
+                  if (browseTeam) setBrowseTeam(null);
+                  else if (browseDept) setBrowseDept(null);
+                  else if (browseDiv) setBrowseDiv(null);
+                }}
+                onRoot={() => {
+                  setBrowseDiv(null);
+                  setBrowseDept(null);
+                  setBrowseTeam(null);
+                }}
+                onDivCrumb={() => {
+                  setBrowseDept(null);
+                  setBrowseTeam(null);
+                }}
+                onDeptCrumb={() => {
+                  setBrowseTeam(null);
+                }}
+                onOpenCard={(r) => setSelected(r)}
+              />
+            )
           ) : view === "cards" ? (
             <CardsView
               records={filtered}

--- a/src/components/BrowseView.tsx
+++ b/src/components/BrowseView.tsx
@@ -1,63 +1,127 @@
-import React, { useMemo, useState, useRef, useLayoutEffect, useEffect } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import React, {
+  useMemo,
+  useState,
+  useRef,
+  useLayoutEffect,
+  useEffect,
+} from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { DirectoryRecord } from "@/types";
 import { CardsView } from "./CardsView";
 import { RegionPill } from "./RegionPill";
-import { show, uniqSorted, personId, managerId, sortOrderNum, normalize, hierarchyClasses } from "@/utils";
+import {
+  show,
+  uniqSorted,
+  personId,
+  managerId,
+  sortOrderNum,
+  normalize,
+  hierarchyClasses,
+} from "@/utils";
 
 // ----------------------------- Browse (Divisions → Depts → Teams) -----------------------------
-function BrowseView({ data, selectedDiv, selectedDept, selectedTeam, onDiv, onDept, onTeam, onBack, onOpenCard, onRoot, onDivCrumb, onDeptCrumb }:{
+export function BrowseView({
+  data,
+  selectedDiv,
+  selectedDept,
+  selectedTeam,
+  onDiv,
+  onDept,
+  onTeam,
+  onBack,
+  onOpenCard,
+  onRoot,
+  onDivCrumb,
+  onDeptCrumb,
+}: {
   data: DirectoryRecord[];
   selectedDiv: string | null;
   selectedDept: string | null;
   selectedTeam: string | null;
-  onDiv: (d:string)=>void;
-  onDept: (d:string)=>void;
-  onTeam: (t:string)=>void;
-  onBack: ()=>void;
-  onOpenCard: (r:DirectoryRecord)=>void;
-  onRoot?: ()=>void;
-  onDivCrumb?: ()=>void;
-  onDeptCrumb?: ()=>void;
-}){
+  onDiv: (d: string) => void;
+  onDept: (d: string) => void;
+  onTeam: (t: string) => void;
+  onBack: () => void;
+  onOpenCard: (r: DirectoryRecord) => void;
+  onRoot?: () => void;
+  onDivCrumb?: () => void;
+  onDeptCrumb?: () => void;
+}) {
   const [orgVisible, setOrgVisible] = useState(true);
 
-  const divisions = useMemo(()=> uniqSorted(data.map(r=> r.Division).filter(show) as string[]), [data]);
-  const deptsInDiv = useMemo(()=> uniqSorted(data.filter(r=> selectedDiv ? r.Division===selectedDiv : true).map(r=> r.Department).filter(show) as string[]), [data, selectedDiv]);
-  const teamsInDept = useMemo(()=> uniqSorted(data.filter(r=> (selectedDiv ? r.Division===selectedDiv : true) && (selectedDept ? r.Department===selectedDept : true)).map(r=> r.Team).filter(show) as string[]), [data, selectedDiv, selectedDept]);
+  const divisions = useMemo(() => uniqSorted(data.map(r => r.Division).filter(show) as string[]), [data]);
+  const deptsInDiv = useMemo(
+    () =>
+      uniqSorted(
+        data
+          .filter(r => (selectedDiv ? normalize(r.Division) === normalize(selectedDiv) : true))
+          .map(r => r.Department)
+          .filter(show) as string[]
+      ),
+    [data, selectedDiv]
+  );
+  const teamsInDept = useMemo(
+    () =>
+      uniqSorted(
+        data
+          .filter(
+            r =>
+              (selectedDiv ? normalize(r.Division) === normalize(selectedDiv) : true) &&
+              (selectedDept ? normalize(r.Department) === normalize(selectedDept) : true)
+          )
+          .map(r => r.Team)
+          .filter(show) as string[]
+      ),
+    [data, selectedDiv, selectedDept]
+  );
 
-  const peopleInDiv = useMemo(() => data.filter(r => (selectedDiv ? r.Division === selectedDiv : false)), [data, selectedDiv]);
+  const peopleInDiv = useMemo(
+    () =>
+      data.filter(r =>
+        selectedDiv ? normalize(r.Division) === normalize(selectedDiv) : false
+      ),
+    [data, selectedDiv]
+  );
   const peopleInDept = useMemo(
     () =>
       data.filter(r =>
         selectedDiv && selectedDept
-          ? r.Division === selectedDiv && r.Department === selectedDept
+          ? normalize(r.Division) === normalize(selectedDiv) &&
+            normalize(r.Department) === normalize(selectedDept)
           : false
       ),
     [data, selectedDiv, selectedDept]
   );
-  const peopleInTeam = useMemo(() => {
+  const [teamPeople, teamResources] = useMemo(() => {
     const arr = data.filter(r =>
       selectedDiv && selectedDept && selectedTeam
-        ? r.Division === selectedDiv &&
-          r.Department === selectedDept &&
-          r.Team === selectedTeam
+        ? normalize(r.Division) === normalize(selectedDiv) &&
+          normalize(r.Department) === normalize(selectedDept) &&
+          normalize(r.Team) === normalize(selectedTeam)
         : false
     );
+    const people: DirectoryRecord[] = [];
+    const resources: DirectoryRecord[] = [];
+    arr.forEach(r => (personId(r) ? people : resources).push(r));
     if (selectedDiv && selectedDiv.toLowerCase() === "sales") {
       const svps = data.filter(
         r =>
           r.Division === selectedDiv &&
           /senior\s+vice\s+president/i.test(r.Title || "")
       );
-      const ids = new Set(arr.map(r => personId(r)));
+      const ids = new Set(people.map(r => personId(r)));
       svps.forEach(s => {
         const id = personId(s);
-        if (id && !ids.has(id)) arr.push(s);
+        if (id && !ids.has(id)) people.push(s);
       });
     }
-    return arr;
+    return [people, resources];
   }, [data, selectedDiv, selectedDept, selectedTeam]);
 
   const [divPeople, divResources] = useMemo(() => {
@@ -226,12 +290,13 @@ function BrowseView({ data, selectedDiv, selectedDept, selectedTeam, onDiv, onDe
 
       {selectedDiv && selectedDept && selectedTeam && (
         <div className="space-y-4">
-          <CardsView records={peopleInTeam} selected={null} onToggle={onOpenCard} />
+          <CardsView records={teamPeople} selected={null} onToggle={onOpenCard} />
+          {teamResources.length > 0 && <ResourceCallouts items={teamResources} />}
           {orgVisible && (
             <>
               <div className="text-sm font-medium text-slate-700">Team Org Chart</div>
               <OrgMarketingChart
-                rows={peopleInTeam}
+                rows={teamPeople}
                 divisionName={selectedDiv!}
                 onOpenCard={onOpenCard}
               />
@@ -308,19 +373,23 @@ function OrgMarketingChart({ rows, divisionName, onOpenCard }:{ rows: DirectoryR
     const tCenterX = trect.left + trect.width/2 - crect.left;
     const tBottomY = trect.bottom - crect.top;
 
-    const childCenters = Array.from(directRefs.current.values()).map(el=>{
+    const childCenters = Array.from(directRefs.current.values()).map(el => {
       const r = el.getBoundingClientRect();
-      return { x: r.left + r.width/2 - crect.left, yTop: r.top - crect.top };
+      return { x: r.left + r.width / 2 - crect.left, yTop: r.top - crect.top };
     });
     if (childCenters.length === 0) { setSharedSegments([]); return; }
-    const minX = Math.min(...childCenters.map(c=>c.x));
-    const maxX = Math.max(...childCenters.map(c=>c.x));
-    const yMid = tBottomY + 24;
+    const minX0 = Math.min(...childCenters.map(c => c.x));
+    const maxX0 = Math.max(...childCenters.map(c => c.x));
+    const topMost = Math.min(...childCenters.map(c => c.yTop));
+    const yMid = Math.max(tBottomY + 24, topMost - 24);
+    const pad = childCenters.length === 1 ? 24 : 0;
+    const minX = minX0 - pad;
+    const maxX = maxX0 + pad;
 
-    const segs:any[] = [];
+    const segs: any[] = [];
     segs.push({ x1: tCenterX, y1: tBottomY, x2: tCenterX, y2: yMid });
     segs.push({ x1: minX, y1: yMid, x2: maxX, y2: yMid });
-    childCenters.forEach(cc=> segs.push({ x1: cc.x, y1: yMid, x2: cc.x, y2: cc.yTop }));
+    childCenters.forEach(cc => segs.push({ x1: cc.x, y1: yMid, x2: cc.x, y2: cc.yTop }));
     setSharedSegments(segs);
     setSvgBox({ w: crect.width, h: crect.height });
   };
@@ -342,7 +411,11 @@ function OrgMarketingChart({ rows, divisionName, onOpenCard }:{ rows: DirectoryR
 
   const { tier2, tier3 } = useMemo(() => {
     if (!isSales) return { tier2: directs, tier3: [] as DirectoryRecord[] };
-    const vps = directs.filter(d => /vice\s+president|vp/i.test(d.Title || ""));
+    const vps = directs.filter(d => {
+      const t = (d.Title || "").toLowerCase();
+      return /(vice\s+president|\bvp\b)/.test(t) &&
+        !/(assistant\s+vice\s+president|\bavp\b)/.test(t);
+    });
     const others = directs.filter(d => !vps.includes(d));
     return { tier2: vps, tier3: others };
   }, [directs, isSales]);
@@ -358,18 +431,30 @@ function OrgMarketingChart({ rows, divisionName, onOpenCard }:{ rows: DirectoryR
         </div>
         {isFMD ? (
           hasSub && (
-            <div className="mt-2">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  setOpenVP(opened ? null : id);
-                  requestAnimationFrame(recomputeTopConnectors);
-                }}
-              >
-                {opened ? "Hide Org" : "Show Org"}
-              </Button>
-            </div>
+            <>
+              <div className="mt-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setOpenVP(opened ? null : id);
+                    requestAnimationFrame(recomputeTopConnectors);
+                  }}
+                >
+                  {opened ? "Hide Org" : "Show Org"}
+                </Button>
+              </div>
+              {opened && (
+                <div className="mt-2 flex justify-center">
+                  <VerticalStackSubtree
+                    parentId={id}
+                    childrenMap={children}
+                    depth={2}
+                    onOpenCard={onOpenCard}
+                  />
+                </div>
+              )}
+            </>
           )
         ) : (
           <VerticalStackSubtree
@@ -406,11 +491,6 @@ function OrgMarketingChart({ rows, divisionName, onOpenCard }:{ rows: DirectoryR
             {tier3.map(n => renderDirect(n))}
           </div>
         )}
-        {isFMD && openVP && (
-          <div className="absolute left-0 right-0 top-full mt-4 flex justify-center">
-            <VerticalStackSubtree parentId={openVP} childrenMap={children} depth={2} onOpenCard={onOpenCard} />
-          </div>
-        )}
       </div>
     </div>
   );
@@ -418,6 +498,32 @@ function OrgMarketingChart({ rows, divisionName, onOpenCard }:{ rows: DirectoryR
 function VerticalStackSubtree({ parentId, childrenMap, depth, onOpenCard }:{ parentId:string; childrenMap: Map<string, DirectoryRecord[]>; depth: number; onOpenCard:(r:DirectoryRecord)=>void }){
   const kids = (childrenMap.get(parentId) || []).slice();
   if (kids.length === 0) return null;
+
+  const isManagerLevel = kids.every(k => {
+    const t = (k.Title || "").toLowerCase();
+    return /manager|director|vice\s+president|vp|chief|president|avp|assistant\s+vice\s+president/.test(t);
+  });
+
+  if (isManagerLevel) {
+    return (
+      <div className="mt-6 flex flex-wrap items-start justify-center gap-6">
+        {kids.map(k => {
+          const id = personId(k)!;
+          const hasSub = (childrenMap.get(id) || []).length > 0;
+          return (
+            <div key={id} className="text-center">
+              <OrgMiniCard node={k} depth={depth} onOpenCard={onOpenCard} />
+              {hasSub && (
+                <div className="mt-2">
+                  <VerticalStackSubtree parentId={id} childrenMap={childrenMap} depth={depth+1} onOpenCard={onOpenCard} />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
 
   return (
     <div className="relative mt-6 ml-10">
@@ -474,5 +580,3 @@ function ResourceCallouts({ items }:{ items: DirectoryRecord[] }){
     </div>
   );
 }
-
-export { BrowseView };


### PR DESCRIPTION
## Summary
- normalize division, department and team comparisons so team contact cards always render above org charts
- standardize top-level org chart connector spacing and exclude AVP roles from VP row in Sales
- export `BrowseView` once to avoid block-scoped redeclaration errors

## Testing
- `npm test` *(fails: vitest: not found)*
- `npx tsc --noEmit` *(fails: Property 'side' does not exist on type 'SheetContentProps'; Cannot find module 'vitest')*


------
https://chatgpt.com/codex/tasks/task_e_689e0630fb9c832ba5f4734ba0ee1d41