### PR TITLE
fix: remove duplicate connector logic

### DIFF
--- a/src/components/BrowseView.tsx
+++ b/src/components/BrowseView.tsx
@@ -394,41 +394,11 @@ function OrgMarketingChart({ rows, divisionName, onOpenCard }:{ rows: DirectoryR
     const segments: {x1:number;y1:number;x2:number;y2:number}[] = [];
     segments.push({ x1: topCenterX, y1: topBottomY, x2: topCenterX, y2: midY });
     segments.push({ x1: minX, y1: midY, x2: maxX, y2: midY });
-    directCenters.forEach((cc) =>
-      segments.push({ x1: cc.x, y1: midY, x2: cc.x, y2: cc.yTop })
-    );
-    setSharedSegments(segments);
-    setSvgBox({ w: containerRect.width, h: containerRect.height });
-    const c = contRef.current; const tp = topRef.current;
-    if (!c || !tp) return;
-    const crect = c.getBoundingClientRect();
-    const trect = tp.getBoundingClientRect();
-    const tCenterX = trect.left + trect.width/2 - crect.left;
-    const tBottomY = trect.bottom - crect.top;
-
-    const childCenters = Array.from(directRefs.current.values()).map(el => {
-      const r = el.getBoundingClientRect();
-      return { x: r.left + r.width / 2 - crect.left, yTop: r.top - crect.top };
-    });
-    if (childCenters.length === 0) { setSharedSegments([]); return; }
-    const minX0 = Math.min(...childCenters.map(c => c.x));
-    const maxX0 = Math.max(...childCenters.map(c => c.x));
-    const topMost = Math.min(...childCenters.map(c => c.yTop));
-    const yMid = Math.max(tBottomY + 24, topMost - 24);
-    const pad = childCenters.length === 1 ? 24 : 0;
-    const minX = minX0 - pad;
-    const maxX = maxX0 + pad;
-    const segs: any[] = [];
-    const segs: any[] = [];
-    const minX = Math.min(...childCenters.map(c=>c.x));
-    const maxX = Math.max(...childCenters.map(c=>c.x));
-    const yMid = tBottomY + 32;
-    const segs:any[] = [];
-    segs.push({ x1: tCenterX, y1: tBottomY, x2: tCenterX, y2: yMid });
-    segs.push({ x1: minX, y1: yMid, x2: maxX, y2: yMid });
-    childCenters.forEach(cc => segs.push({ x1: cc.x, y1: yMid, x2: cc.x, y2: cc.yTop }));
-    setSharedSegments(segs);
-    setSvgBox({ w: crect.width, h: crect.height });
+      directCenters.forEach((cc) =>
+        segments.push({ x1: cc.x, y1: midY, x2: cc.x, y2: cc.yTop })
+      );
+      setSharedSegments(segments);
+      setSvgBox({ w: containerRect.width, h: containerRect.height });
   };
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## Summary
- remove duplicate top connector calculations to prevent redeclared variables

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_689e1ad98350832b9eb07386c826f9f3