### PR TITLE
feat: highlight division leadership and improve org chart

### DIFF
--- a/src/components/BrowseView.tsx
+++ b/src/components/BrowseView.tsx
@@ -193,6 +193,13 @@ export function BrowseView({
 
       {selectedDiv && !selectedDept && (
         <div className="space-y-4">
+          {divPeople.length > 0 && (
+            <>
+              <div className="text-sm font-medium text-slate-700">Leadership</div>
+              <CardsView records={divPeople} selected={null} onToggle={onOpenCard} />
+            </>
+          )}
+
           {deptsInDiv.length > 0 && (
             <>
               <div className="text-sm font-medium text-slate-700">Departments</div>
@@ -218,10 +225,6 @@ export function BrowseView({
                 ))}
               </div>
             </>
-          )}
-
-          {divPeople.length > 0 && (
-            <CardsView records={divPeople} selected={null} onToggle={onOpenCard} />
           )}
 
           {divResources.length > 0 && <ResourceCallouts items={divResources} />}

--- a/src/components/OrgChart.tsx
+++ b/src/components/OrgChart.tsx
@@ -30,9 +30,11 @@ export function OrgChart({ rows, onOpenCard }:{ rows: DirectoryRecord[]; onOpenC
   if (roots.length === 0) return <div className="text-sm text-slate-600">No hierarchy data found.</div>;
 
   return (
-    <div className="space-y-6">
+    <div className="columns-1 sm:columns-2 lg:columns-3 gap-6">
       {roots.map(r => (
-        <OrgNode key={personId(r)!} node={r} childrenMap={children} depth={0} onOpenCard={onOpenCard} />
+        <div key={personId(r)!} className="mb-6 break-inside-avoid">
+          <OrgNode node={r} childrenMap={children} depth={0} onOpenCard={onOpenCard} />
+        </div>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- show division leadership contacts above departments in browse view
- lay out root org chart entries in responsive columns to shorten long charts

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e2cc0570c832bb657320d38892d45