### PR TITLE
feat: add VP-level expand collapse to org chart

### DIFF
--- a/src/components/OrgChart.tsx
+++ b/src/components/OrgChart.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { DirectoryRecord } from "@/types";
 import { personId, managerId, hierarchyClasses } from "@/utils";
 import { RegionPill } from "./RegionPill";
@@ -29,24 +29,55 @@ export function OrgChart({ rows, onOpenCard }:{ rows: DirectoryRecord[]; onOpenC
   const roots = children.get("__ROOT__") || [];
   if (roots.length === 0) return <div className="text-sm text-slate-600">No hierarchy data found.</div>;
 
+  const [expandedRoot, setExpandedRoot] = useState<string | null>(null);
+
   return (
     <div className="columns-1 sm:columns-2 lg:columns-3 gap-6">
-      {roots.map(r => (
-        <div key={personId(r)!} className="mb-6 break-inside-avoid">
-          <OrgNode node={r} childrenMap={children} depth={0} onOpenCard={onOpenCard} />
-        </div>
-      ))}
+      {roots.map(r => {
+        const id = personId(r)!;
+        const expanded = expandedRoot === id;
+        return (
+          <div key={id} className="mb-6 break-inside-avoid">
+            <OrgNode
+              node={r}
+              childrenMap={children}
+              depth={0}
+              expanded={expanded}
+              onToggle={() => setExpandedRoot(expanded ? null : id)}
+              onOpenCard={onOpenCard}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 }
 
-function OrgNode({ node, childrenMap, depth, onOpenCard }:{ node: DirectoryRecord; childrenMap: Map<string, DirectoryRecord[]>; depth: number; onOpenCard:(r:DirectoryRecord)=>void }){
+function OrgNode({ node, childrenMap, depth, expanded, onToggle, onOpenCard }:{ node: DirectoryRecord; childrenMap: Map<string, DirectoryRecord[]>; depth: number; expanded?: boolean; onToggle?: () => void; onOpenCard:(r:DirectoryRecord)=>void }){
   const id = personId(node)!;
   const kids = childrenMap.get(id) || [];
+  const isRoot = depth === 0;
+  const showKids = !isRoot || expanded;
+
   return (
     <div>
-      <OrgCard node={node} depth={depth} onOpenCard={onOpenCard} />
-      {kids.length > 0 && (
+      <OrgCard
+        node={node}
+        depth={depth}
+        onOpenCard={onOpenCard}
+        action={isRoot && kids.length > 0 ? (
+          <button
+            className="text-xs underline"
+            onClick={e => {
+              e.stopPropagation();
+              onToggle?.();
+            }}
+          >
+            {expanded ? "Collapse" : "Expand"}
+          </button>
+        ) : undefined}
+      />
+      {showKids && kids.length > 0 && (
         <div className="ml-8 mt-3 border-l border-[#C3CFDA] pl-4 space-y-3">
           {kids.map(k => (
             <OrgNode key={personId(k)!} node={k} childrenMap={childrenMap} depth={depth+1} onOpenCard={onOpenCard} />
@@ -57,9 +88,13 @@ function OrgNode({ node, childrenMap, depth, onOpenCard }:{ node: DirectoryRecor
   );
 }
 
-function OrgCard({ node, depth, onOpenCard }:{ node: DirectoryRecord; depth: number; onOpenCard:(r:DirectoryRecord)=>void }){
+function OrgCard({ node, depth, onOpenCard, action }:{ node: DirectoryRecord; depth: number; onOpenCard:(r:DirectoryRecord)=>void; action?: React.ReactNode }){
   return (
-    <div className={`rounded-xl border px-3 py-2 cursor-pointer hover:shadow w-64 ${hierarchyClasses(depth)}`} onClick={() => onOpenCard(node)}>
+    <div
+      className={`relative rounded-xl border px-3 py-2 cursor-pointer hover:shadow w-64 ${hierarchyClasses(depth)}`}
+      onClick={() => onOpenCard(node)}
+    >
+      {action && <div className="absolute top-1 right-1">{action}</div>}
       <div className="font-medium leading-snug break-words text-center">{node.Name}</div>
       {node.Title && <div className="text-xs leading-snug break-words text-center opacity-90">{node.Title}</div>}
       <div className="flex flex-wrap gap-1 mt-2 justify-center">


### PR DESCRIPTION
## Summary
- add expand/collapse toggle for VP cards in org chart
- only one VP's org open at a time

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/acorn-walk)*

------
https://chatgpt.com/codex/tasks/task_e_689e32baf28c832b95c64258cdaa3517